### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Oxford102/bootstrap.py
+++ b/Oxford102/bootstrap.py
@@ -49,7 +49,7 @@ cwd = os.path.dirname(os.path.realpath(__file__))
 def write_set_file(fout, labels):
     with open(fout, 'w+') as f:
         for label in labels:
-            f.write('%s/%s %s\n' % (cwd, label[0], label[1]))
+            f.write('{0!s}/{1!s} {2!s}\n'.format(cwd, label[0], label[1]))
 
 # Images are ordered by species, so shuffle them
 np.random.seed(777)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:fish145:fine-tuning?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:fish145:fine-tuning?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
